### PR TITLE
Handle un-configured bundle loading

### DIFF
--- a/src/DependencyInjection/Extension.php
+++ b/src/DependencyInjection/Extension.php
@@ -63,7 +63,7 @@ final class Extension extends BaseExtension
         $classMapping = $config['class_mapping'];
 
         foreach ([
-            AttributeRepository::class => $classMapping[Attribute::class],
+            AttributeRepository::class => $classMapping[Attribute::class] ?? null,
         ] as $repository => $class) {
             if (null === $class) {
                 $container->removeDefinition($repository);


### PR DESCRIPTION
Use-case: Fresh Symfony project install and running `composer require`